### PR TITLE
Set up a test-specific Redis daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+dump.rdb

--- a/test/snazz/concurrent/semaphore_test.rb
+++ b/test/snazz/concurrent/semaphore_test.rb
@@ -10,7 +10,7 @@ module Snazz
       TIMEOUT = 100
 
       def setup
-        @connection = Redis.new(url: "redis://localhost:6379")
+        @connection = Redis.new(url: redis_url)
         @subject = Semaphore.new(KEY, @connection, 1, 500)
         @connection.flushdb
       end

--- a/test/snazz/middleware/throttling_middleware_test.rb
+++ b/test/snazz/middleware/throttling_middleware_test.rb
@@ -4,7 +4,7 @@ module Snazz
   module Middleware
     class ThrottlingMiddlewareTest < Minitest::Test
       def setup
-        @connection = Redis.new(url: "redis://localhost:6379")
+        @connection = Redis.new(url: redis_url)
         @subject = ThrottlingMiddleware.new
         @worker = Snazz::Worker::ThrottledWorker.new
         @queue = "default"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,33 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'snazz'
+require 'tempfile'
+
+redis = `which redis-server`.chomp
+if redis.empty?
+  warn "No redis-server executable found"
+  exit 1
+end
+ENV['REDIS_PORT'] ||= ENV.fetch('REDIS_PORT', '9736')
+redis_pidfile = Tempfile.new('snazz_redis')
+system redis,
+       '--daemonize', 'yes',
+       '--port', ENV['REDIS_PORT'],
+       '--pidfile', redis_pidfile.path
+
+##
+# Builds a connection URL string for the test-specific Redis daemon.
+def redis_url(host = 'localhost', port = ENV['REDIS_PORT'])
+  "redis://#{host}:#{port}"
+end
+
+Sidekiq.redis = { url: redis_url }
+
+at_exit do
+  pid = File.read(redis_pidfile.path).to_i
+  Process.kill('TERM', pid) unless pid.zero?
+
+  redis_pidfile.close
+  redis_pidfile.unlink
+end
 
 require 'minitest/autorun'


### PR DESCRIPTION
This will hopefully avoid clobbering a developer's local Redis database.
