### PR TITLE
Allow throttle key to be set by perform_async call

### DIFF
--- a/lib/snazz/worker/periodic_worker.rb
+++ b/lib/snazz/worker/periodic_worker.rb
@@ -1,6 +1,6 @@
 module Snazz
   module Worker
-    class PeriodicWorker
+    module PeriodicWorker
     end
   end
 end

--- a/lib/snazz/worker/sequential_worker.rb
+++ b/lib/snazz/worker/sequential_worker.rb
@@ -1,6 +1,6 @@
 module Snazz
   module Worker
-    class SequentialWorker
+    module SequentialWorker
     end
   end
 end

--- a/lib/snazz/worker/singleton_worker.rb
+++ b/lib/snazz/worker/singleton_worker.rb
@@ -1,6 +1,6 @@
 module Snazz
   module Worker
-    class SingletonWorker
+    module SingletonWorker
     end
   end
 end

--- a/lib/snazz/worker/throttled_worker.rb
+++ b/lib/snazz/worker/throttled_worker.rb
@@ -1,11 +1,28 @@
 module Snazz
   module Worker
-    class ThrottledWorker
-      DEFAULT_KEY = "snazz:throttled"
+    module ThrottledWorker
+      DEFAULT_KEY = "snazz:throttled".freeze
 
       DEFAULT_LEASE_COUNT = 1
 
       DEFAULT_TIMEOUT = 1_000
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        # Overrides the basic Sidekiq::Worker version to append an options hash
+        # with a key string that will provide the throttling scope for the job.
+        def perform_async(*args, key: nil)
+          if key
+            args.push("key".freeze => key)
+          else
+            args.push({})
+          end
+          super(*args)
+        end
+      end
 
       def key
         DEFAULT_KEY

--- a/test/snazz/middleware/throttling_middleware_test.rb
+++ b/test/snazz/middleware/throttling_middleware_test.rb
@@ -3,18 +3,27 @@ require "test_helper"
 module Snazz
   module Middleware
     class ThrottlingMiddlewareTest < Minitest::Test
+      class FakeWorker
+        include Snazz::Worker::ThrottledWorker
+      end
+
       def setup
         @connection = Redis.new(url: redis_url)
         @subject = ThrottlingMiddleware.new
-        @worker = Snazz::Worker::ThrottledWorker.new
+        @worker = FakeWorker.new
         @queue = "default"
+        @throttle_key = "throttled"
         @connection.flushdb
+      end
+
+      def a_job
+        {"args" => [{"key" => @throttle_key}]}
       end
 
       def test_it_skips_workers_that_arent_throttled
         called = false
 
-        @subject.call("other worker", {}, @queue) do
+        @subject.call("other worker", a_job, @queue) do
           called = true
         end
 
@@ -22,17 +31,25 @@ module Snazz
       end
 
       def test_it_acquires_a_lock_when_called_with_a_throttled_worker
-        @subject.call(@worker, {}, @queue) do
-          assert_equal 1, @connection.zcount(@worker.key, "-inf", "+inf")
+        @subject.call(@worker, a_job, @queue) do
+          assert_equal 1, @connection.zcount(@throttle_key, "-inf", "+inf")
         end
       end
 
       def test_it_reschedules_workers_when_a_lock_cannot_be_held
-        @subject.call(@worker, {}, @queue) do
-          @subject.call(@worker, {}, @queue) {}
+        @subject.call(@worker, a_job, @queue) do
+          @subject.call(@worker, a_job, @queue) {}
         end
 
         assert_equal 1, @connection.llen("queue:#{@queue}")
+      end
+
+      def test_it_uses_key_specified_in_job_options
+        job = {"args" => [{"key" => "override"}]}
+        @subject.call(@worker, job, @queue) do
+          assert_equal 1, @connection.zcount("override", "-inf", "+inf")
+          assert_equal 0, @connection.zcount(@worker.key, "-inf", "+inf")
+        end
       end
     end
   end

--- a/test/snazz/worker/throttled_worker_test.rb
+++ b/test/snazz/worker/throttled_worker_test.rb
@@ -4,8 +4,12 @@ require "snazz/worker/throttled_worker"
 module Snazz
   module Worker
     class ThrottledWorkerTest < Minitest::Test
+      class FakeWorker
+        include Snazz::Worker::ThrottledWorker
+      end
+
       def setup
-        @subject = Snazz::Worker::ThrottledWorker.new
+        @subject = FakeWorker.new
       end
 
       def test_it_has_a_key
@@ -18,6 +22,26 @@ module Snazz
 
       def test_it_has_a_timeout
         assert_equal Snazz::Worker::ThrottledWorker::DEFAULT_TIMEOUT, @subject.timeout
+      end
+
+      def test_perform_async_sets_options
+        worker_class = Class.new do
+          # Simulate including Sidekiq::Worker
+          extend(Module.new do
+            def called_with
+              @called_with
+            end
+
+            def perform_async(*args)
+              @called_with = args
+            end
+          end)
+
+          include Snazz::Worker::ThrottledWorker
+        end
+        worker_class.perform_async(key: "override")
+        assert_equal [{"key" => "override"}],
+                     worker_class.called_with
       end
     end
   end


### PR DESCRIPTION
Also switches all middlewares to modules, for easier cooperation with
Sidekiq::Worker.
